### PR TITLE
Allow SystemJS builder bundle arithmethic

### DIFF
--- a/tasks/systemjs-builder.js
+++ b/tasks/systemjs-builder.js
@@ -82,7 +82,7 @@ module.exports = function (grunt) {
 
 		var builder = data.builder,
 			options = data.options,
-			src = file.src[0];
+			src = file.src[0] || file.orig.src[0]; //falls back the this original string which may include arithmetic. if not it'll fail also
 
 		grunt.verbose.writeln("systemjs-builder-task - about to build source: " + src);
 


### PR DESCRIPTION
I didn't see tests I could run to prove this works with every scenario but I modified my code locally and it works fine for both arithmetic and specifying a trace tree trunk. Plus you don't have to specify that you are doing arithmetic, which is a plus
