### PR TITLE
added missing comma in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ grunt.initConfig({
 	            options: {
 	                sfx: true,
 	                baseURL: "./target",
-	                configFile: "./target/config.js"
+	                configFile: "./target/config.js",
                 	minify: true,
 					build: {
 					  mangle: false


### PR DESCRIPTION
I just added a missing comma to the example in the doc
